### PR TITLE
Remove reliance on jest and jasmine types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+docs/
 reports/
 *.tgz
 $WORKSPACE/.npmrc

--- a/main/mock/contracts.ts
+++ b/main/mock/contracts.ts
@@ -259,3 +259,26 @@ export interface IMocked<T, C extends new (...args: any[]) => T = never> {
         propertyname: K,
     ): IFunctionWithParametersVerification<[C[K]], T, 'staticSetter', C>;
 }
+
+/**
+ * Copied here from Jest types to avoid the need for consuming projects to install Jest types
+ */
+export interface IJestCustomMatcherResult {
+    pass: boolean;
+    message: () => string;
+}
+
+/**
+ * Copied here from Jasmine types to avoid the need for consuming projects to install Jasmine types
+ */
+export interface IJasmineCustomMatcherResult {
+    pass: boolean;
+    message?: string;
+}
+
+export interface ICustomMatcher {
+    compare<T>(actual: T, expected: T, ...args: any[]): IJasmineCustomMatcherResult;
+    compare(actual: any, ...expected: any[]): IJasmineCustomMatcherResult;
+    negativeCompare?<T>(actual: T, expected: T, ...args: any[]): IJasmineCustomMatcherResult;
+    negativeCompare?(actual: any, ...expected: any[]): IJasmineCustomMatcherResult;
+}

--- a/main/mock/matchers.ts
+++ b/main/mock/matchers.ts
@@ -1,4 +1,4 @@
-import { IFunctionVerifier } from './contracts';
+import { ICustomMatcher, IFunctionVerifier } from './contracts';
 import { verifyFunctionCalled } from './verifiers';
 
 declare global {
@@ -38,7 +38,7 @@ export function addMatchers() {
     }
 }
 
-function wasCalled(): jasmine.CustomMatcher {
+function wasCalled(): ICustomMatcher {
     return {
         compare: (actual: IFunctionVerifier<any, any>, times: number) => {
             if (typeof times !== 'number') {
@@ -52,7 +52,7 @@ function wasCalled(): jasmine.CustomMatcher {
     };
 }
 
-function wasCalledOnce(): jasmine.CustomMatcher {
+function wasCalledOnce(): ICustomMatcher {
     return {
         compare: (actual: IFunctionVerifier<any, any>) => {
             return verifyFunctionCalled(1, actual) as any;
@@ -60,7 +60,7 @@ function wasCalledOnce(): jasmine.CustomMatcher {
     };
 }
 
-function wasNotCalled(): jasmine.CustomMatcher {
+function wasNotCalled(): ICustomMatcher {
     return {
         compare: (actual: IFunctionVerifier<any, any>) => {
             return verifyFunctionCalled(0, actual) as any;
@@ -68,7 +68,7 @@ function wasNotCalled(): jasmine.CustomMatcher {
     };
 }
 
-function wasCalledAtLeastOnce(): jasmine.CustomMatcher {
+function wasCalledAtLeastOnce(): ICustomMatcher {
     return {
         compare: (actual: IFunctionVerifier<any, any>) => {
             return verifyFunctionCalled(undefined, actual) as any;

--- a/main/mock/mock.ts
+++ b/main/mock/mock.ts
@@ -1,4 +1,5 @@
 import { FunctionsOnly, IMocked, OperatorFunction } from './contracts';
+import { addMatchers } from './matchers';
 import {
     defineProperty,
     defineStaticProperty,
@@ -11,6 +12,7 @@ import { createFunctionParameterVerifier, createFunctionVerifier } from './verif
 
 export class Mock {
     public static create<T, C extends new (...args: any[]) => T = never>(): IMocked<T, C> {
+        addMatchers();
         const mocked: IMocked<T, C> = {
             functionCallLookup: {},
             setterCallLookup: {},

--- a/main/mock/operators.ts
+++ b/main/mock/operators.ts
@@ -7,7 +7,6 @@ import {
     IMocked,
     OperatorFunction,
 } from './contracts';
-import { addMatchers } from './matchers';
 
 /**
  * Mocks a function on an existing Mock.
@@ -219,8 +218,6 @@ function trackSetterCall<T, C extends ConstructorFunction<T>>(
 }
 
 function trackCall(lookup: FunctionCallLookup, name: string, params: any[]) {
-    addMatchers();
-
     if (lookup[name as any] === undefined) {
         lookup[name as any] = [];
     }

--- a/main/mock/verifiers.ts
+++ b/main/mock/verifiers.ts
@@ -6,6 +6,8 @@ import {
     FunctionType,
     IFunctionVerifier,
     IFunctionWithParametersVerification,
+    IJasmineCustomMatcherResult,
+    IJestCustomMatcherResult,
     IMocked,
     IParameterMatcher,
     IStrictFunctionVerification,
@@ -129,7 +131,7 @@ function mapParameterToMatcher(
 export function verifyFunctionCalled<T, C extends ConstructorFunction<T>, U extends FunctionType>(
     times: number | undefined,
     verifier: IFunctionVerifier<T, U, C>,
-): jasmine.CustomMatcherResult | jest.CustomMatcherResult {
+): IJasmineCustomMatcherResult | IJestCustomMatcherResult {
     const mock = verifier.getMock();
     const type = verifier.type;
     const functionName = verifier.functionName;
@@ -297,8 +299,8 @@ function functionCallToString(call: any[], parameterMatchers?: ParameterMatcher<
 }
 
 function isMatcherResultArray(
-    paramResult: boolean | (jasmine.CustomMatcherResult | jest.CustomMatcherResult)[],
-): paramResult is (jasmine.CustomMatcherResult | jest.CustomMatcherResult)[] {
+    paramResult: boolean | (IJasmineCustomMatcherResult | IJestCustomMatcherResult)[],
+): paramResult is (IJasmineCustomMatcherResult | IJestCustomMatcherResult)[] {
     if (Array.isArray(paramResult)) {
         return paramResult.every(isMatcherResult);
     }
@@ -308,10 +310,10 @@ function isMatcherResultArray(
 function isMatcherResult(
     paramResult:
         | boolean
-        | jasmine.CustomMatcherResult
-        | jest.CustomMatcherResult
-        | (jasmine.CustomMatcherResult | jest.CustomMatcherResult)[],
-): paramResult is jasmine.CustomMatcherResult | jest.CustomMatcherResult {
+        | IJasmineCustomMatcherResult
+        | IJestCustomMatcherResult
+        | (IJasmineCustomMatcherResult | IJestCustomMatcherResult)[],
+): paramResult is IJasmineCustomMatcherResult | IJestCustomMatcherResult {
     if (Array.isArray(paramResult)) {
         return paramResult.every(isMatcherResult);
     }
@@ -321,7 +323,7 @@ function isMatcherResult(
 function matchParameters(
     actualParameters: any[],
     parameterMatchers?: (IParameterMatcher<any> | MatchFunction<any>)[],
-): boolean | (jasmine.CustomMatcherResult | jest.CustomMatcherResult)[] {
+): boolean | (IJasmineCustomMatcherResult | IJestCustomMatcherResult)[] {
     if (parameterMatchers == null) {
         return true;
     }
@@ -341,7 +343,7 @@ function matchParameters(
 function evaluateParameterMatcher(
     actualParam: any,
     matcher: IParameterMatcher<any> | MatchFunction<any>,
-): boolean | jasmine.CustomMatcherResult | jest.CustomMatcherResult {
+): boolean | IJasmineCustomMatcherResult | IJestCustomMatcherResult {
     if (typeof matcher === 'function') {
         let matcherReturnValue: boolean;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/ts-mocking-bird",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/ts-mocking-bird",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "description": "A fully type safe mocking, call verification and import replacement library for jasmine and jest",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",

--- a/readme.md
+++ b/readme.md
@@ -24,13 +24,7 @@ Documentation: https://morgan-stanley.github.io/ts-mocking-bird/
 
 # Typescript Version
 
-Requires a minimum Typescript version of 3.1. You must also enable `skipLibCheck` in your tsconfig.json file as the library makes use of optional type definitions for jasmine and jest internally.  
-
-```json
-{
-    "skipLibCheck": true,
-}
-```
+Requires a minimum Typescript version of 3.1. 
 
 # Framework support
 

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ const systemUnderTest = new ClassWithConstructorArgument(mockedService.mockConst
 
 ### Jasmine / Jest Matchers
 
-When a mocked function is setup the custom matchers that are used by `ts-mocking-bird` are automatically setup. However this can only be done if this setup occurs within a `before` function. If you need to manually setup the custom matchers please call `addMatchers()`:
+When a mock is created using `Mock.create()` the custom matchers that are used by `ts-mocking-bird` are automatically setup. However this can only be done if the creation occurs within a `before` function. If you need to manually setup the custom matchers please call `addMatchers()`:
 
 ```typescript
 import { addMatchers } from '@morgan-stanley/ts-mocking-bird'

--- a/spec/helper/property-replacement-helper.spec.ts
+++ b/spec/helper/property-replacement-helper.spec.ts
@@ -1,4 +1,4 @@
-import { Mock, replaceProperties, replacePropertiesBeforeEach } from '../../main';
+import { addMatchers, Mock, replaceProperties, replacePropertiesBeforeEach } from '../../main';
 import {
     classReturnValue,
     functionOneReturnValue,
@@ -42,6 +42,7 @@ describe('property replacement helper', () => {
     });
 
     beforeEach(() => {
+        addMatchers();
         setterValues = [];
         mockedSetterValues = [];
     });


### PR DESCRIPTION
Removes errors when people try to use in a jest environment with no jasmine types installed