### PR TITLE
Use repository secret to create releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Release
         uses: justincy/github-action-npm-release@2.0.2
         id: release
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Print release output
         if: ${{ steps.release.outputs.released == 'true' }}


### PR DESCRIPTION
Github actoin needs token to create github release