### PR TITLE
Wrap jest expect function test so it is safe to run when expect is not defined

### DIFF
--- a/main/helper/jest-helper.ts
+++ b/main/helper/jest-helper.ts
@@ -24,5 +24,9 @@ export function proxyJestModule(absolutePath: string): WrappedModule {
 }
 
 export function runningInJest(): boolean {
-    return typeof (expect as any).extend === 'function';
+    try {
+        return typeof (expect as any).extend === 'function';
+    } catch (e) {
+        return false;
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@morgan-stanley/ts-mocking-bird",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@morgan-stanley/ts-mocking-bird",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash": "^4.17.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/ts-mocking-bird",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "A fully type safe mocking, call verification and import replacement library for jasmine and jest",
     "license": "Apache-2.0",
     "author": "Morgan Stanley",


### PR DESCRIPTION
This was throwing errors when ran in vitest