### PR TITLE
Validate IFunctionVerifier argument in wasCalled/wasCalledOnce/wasNotCalled/wasCalledAtLeastOnce (fixes #9)

### DIFF
--- a/main/mock/verifiers.ts
+++ b/main/mock/verifiers.ts
@@ -152,10 +152,29 @@ function mapParameterToMatcher(
     return equals ? toEqual(param) : toBe(param);
 }
 
+/**
+ * Returns true if the given value looks like a valid IFunctionVerifier produced by mock.withFunction(),
+ * mock.withGetter(), mock.withSetter(), etc.
+ */
+export function isFunctionVerifier(value: unknown): value is IFunctionVerifier<any, any, any> {
+    if (value == null || typeof value !== 'object') {
+        return false;
+    }
+    const v = value as Record<string, unknown>;
+    return typeof v['type'] === 'string' && 'functionName' in v && typeof v['getMock'] === 'function' && typeof v['strictCallCount'] === 'boolean';
+}
+
 export function verifyFunctionCalled<T, C extends ConstructorFunction<T>, U extends LookupType>(
     times: number | undefined,
     verifier: IFunctionVerifier<T, U, C>,
 ): IJasmineCustomMatcherResult | IJestCustomMatcherResult {
+    if (!isFunctionVerifier(verifier)) {
+        const received = verifier === null ? 'null' : Array.isArray(verifier) ? 'array' : typeof verifier;
+        throw new Error(
+            `Expected an IFunctionVerifier from mock.withFunction() / mock.withGetter() / mock.withSetter() etc.; got ${received}. Did you accidentally pass a raw function, a mock object, or forget to call mock.withFunction()?`,
+        );
+    }
+
     const mock = verifier.getMock();
     const type = verifier.type;
     const functionName = verifier.functionName;

--- a/spec/mock/mock.spec.ts
+++ b/spec/mock/mock.spec.ts
@@ -2681,6 +2681,52 @@ describe('mock', () => {
             });
         });
     });
+
+    describe('IFunctionVerifier argument validation', () => {
+        const invalidArgCases: Array<{ description: string; value: unknown }> = [
+            { description: 'undefined', value: undefined },
+            { description: 'null', value: null },
+            { description: 'a raw function', value: () => {} },
+            { description: 'a plain object', value: { foo: 'bar' } },
+            { description: 'a string', value: 'notAVerifier' },
+            { description: 'a number', value: 42 },
+            { description: 'a mock object (not a verifier)', value: Mock.create<SampleMockedClass>().mock },
+        ];
+
+        invalidArgCases.forEach(({ description, value }) => {
+            describe(`when passed ${description}`, () => {
+                it('wasNotCalled should throw a descriptive Error', () => {
+                    expect(() => matchers.wasNotCalled().compare(value as any)).toThrowError(
+                        /Expected an IFunctionVerifier from mock\.withFunction/,
+                    );
+                });
+
+                it('wasCalledOnce should throw a descriptive Error', () => {
+                    expect(() => matchers.wasCalledOnce().compare(value as any)).toThrowError(
+                        /Expected an IFunctionVerifier from mock\.withFunction/,
+                    );
+                });
+
+                it('wasCalledAtLeastOnce should throw a descriptive Error', () => {
+                    expect(() => matchers.wasCalledAtLeastOnce().compare(value as any)).toThrowError(
+                        /Expected an IFunctionVerifier from mock\.withFunction/,
+                    );
+                });
+
+                it('wasCalled should throw a descriptive Error', () => {
+                    expect(() => matchers.wasCalled().compare(value as any, 1)).toThrowError(
+                        /Expected an IFunctionVerifier from mock\.withFunction/,
+                    );
+                });
+            });
+        });
+
+        it('valid IFunctionVerifier should not throw', () => {
+            mocked.setupFunction('functionWithNoParamsAndNoReturn');
+            const verifier = mocked.withFunction('functionWithNoParamsAndNoReturn');
+            expect(() => matchers.wasNotCalled().compare(verifier)).not.toThrow();
+        });
+    });
 });
 
 class SampleMockedClass {


### PR DESCRIPTION
## Summary

Fixes #9.

Functions like `wasCalledOnce()`, `wasNotCalled()`, `wasCalled()` and `wasCalledAtLeastOnce()` now validate that the value passed to them is an actual `IFunctionVerifier` produced by `mock.withFunction()` / `mock.withGetter()` / `mock.withSetter()` etc.

Previously, accidentally passing a raw function, a mock object, or any other value would cause a cryptic runtime error deep inside the library (typically a `TypeError: verifier.getMock is not a function`). Now they throw an `Error` with a clear message:

```
Expected an IFunctionVerifier from mock.withFunction() / mock.withGetter() / mock.withSetter() etc.;
got function. Did you accidentally pass a raw function, a mock object, or forget to call mock.withFunction()?
```

## Changes

- **`main/mock/verifiers.ts`**: Added exported `isFunctionVerifier(value)` type guard that checks for the required shape (`type`, `functionName`, `getMock`, `strictCallCount`). Added a validation call at the top of `verifyFunctionCalled` that throws an `Error` with a descriptive message if the check fails.

- **`spec/mock/mock.spec.ts`**: Added a `describe('IFunctionVerifier argument validation')` block covering all four matcher functions (`wasCalled`, `wasCalledOnce`, `wasNotCalled`, `wasCalledAtLeastOnce`) across 7 categories of invalid input (`undefined`, `null`, raw function, plain object, string, number, mock object). Also includes a positive test verifying that a valid verifier does not throw.

## Test plan

- [ ] `npm run test:karma -- --no-coverage` — all 406 jasmine tests pass (including 29 new ones)
- [ ] `npm run test:jest` — all jest example tests pass
- [ ] `npm run test:vitest` — all vitest example tests pass